### PR TITLE
feat: added notifications for Telegram group

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -1,4 +1,5 @@
 name: Notify on Push
+run-name: ${{github.actor}} has pushed to main
 
 on:
   push:
@@ -10,9 +11,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Discord Commits
+      - name: Discord Commit
         uses: Sniddl/discord-commits@v1.6
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
           template: "avatar-with-link"
           include-extras: true
+
+      - name: Send Telegram Message on Push
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_TOPIC: ${{ secrets.TELEGRAM_TOPIC }}  # Add topic
+          GITHUB_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GITHUB_COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
+          GITHUB_COMMIT_URL: ${{ github.event.head_commit.url }}
+        run: |
+          curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+          -d chat_id="${TELEGRAM_CHAT_ID}" \
+          -d topic="${TELEGRAM_UPDATES}"
+          -d text="New Commit Pushed:
+      Commit Message: ${GITHUB_COMMIT_MESSAGE}
+      Author: ${GITHUB_COMMIT_AUTHOR}
+      Commit URL: ${GITHUB_COMMIT_URL}"
+
+


### PR DESCRIPTION
Add Telegram topic-based notifications for GitHub commits.
This commit updates the workflow to send notifications to a specific Telegram topic instead of the default chat. The notification includes details of the latest commit, such as the commit message, author, and commit URL. This improves team communication by ensuring that updates are sent to the appropriate topic in the Telegram channel, streamlining notifications for relevant updates.