### PR TITLE
patch: fixed indentation for text message to be published in Telegram group

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -31,6 +31,6 @@ jobs:
           -d chat_id="${TELEGRAM_CHAT_ID}" \
           -d topic="${TELEGRAM_UPDATES}" \
           -d text="New Commit Pushed:
-Commit Message: ${GITHUB_COMMIT_MESSAGE}
-Author: ${GITHUB_COMMIT_AUTHOR}
-Commit URL: ${GITHUB_COMMIT_URL}"
+          Commit Message: ${GITHUB_COMMIT_MESSAGE}
+          Author: ${GITHUB_COMMIT_AUTHOR}
+          Commit URL: ${GITHUB_COMMIT_URL}"


### PR DESCRIPTION
Fix Telegram message formatting in GitHub Actions workflow.
This update corrects the syntax for sending commit notifications to Telegram. The multiline string for the text parameter in the curl command was properly formatted, ensuring the commit message, author, and commit URL are correctly passed and displayed in the Telegram notification. This resolves issues with unexpected values in the message.