### PR TITLE
patch: modified notify.yaml to send commit updates to a thread id in Telegram

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
           -d chat_id="${TELEGRAM_CHAT_ID}" \
-          -d topic="${TELEGRAM_UPDATES}" \
+          -d thread_id="${TELEGRAM_UPDATES}" \
           -d text="New Commit Pushed:
           Commit Message: ${GITHUB_COMMIT_MESSAGE}
           Author: ${GITHUB_COMMIT_AUTHOR}


### PR DESCRIPTION
Send commit notifications to specific Telegram topic using thread_id as topic name does not work.
