### PR TITLE
fix: update Telegram notification to support topic threads

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -22,14 +22,14 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          TELEGRAM_TOPIC: ${{ secrets.TELEGRAM_TOPIC }} # Add topic
+          TELEGRAM_TOPIC_ID: ${{ secrets.TELEGRAM_UPDATES }}  # Rename to TOPIC_ID
           GITHUB_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           GITHUB_COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
           GITHUB_COMMIT_URL: ${{ github.event.head_commit.url }}
         run: |
           curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
           -d chat_id="${TELEGRAM_CHAT_ID}" \
-          -d thread_id="${TELEGRAM_UPDATES}" \
+          -d message_thread_id="${TELEGRAM_UPDATES}" \
           -d text="New Commit Pushed:
           Commit Message: ${GITHUB_COMMIT_MESSAGE}
           Author: ${GITHUB_COMMIT_AUTHOR}


### PR DESCRIPTION
Replace 'topic' parameter with 'message_thread_id' to correctly target supergroup topics
Fix environment variable naming for consistency (TELEGRAM_TOPIC → TELEGRAM_TOPIC_ID)
Update curl command to use proper Telegram API parameters