### PR TITLE
Add automatic deployment after tests pass back into run-tests.yaml

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -199,3 +199,18 @@ jobs:
           context: "Allure Report"
           state: success
           target_url: https://ekitaikani.github.io/DOPAssignment/
+  deploy:
+    needs: setup-and-test
+    runs-on: ubuntu-latest
+    env:
+      RENDER_SERVICE_ID: srv-cub0n952ng1s73al9d10
+      RENDER_API_KEY: rnd_LCopwoiRrFjrciCuPrJaJodXhrbu
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trigger Render Deployment
+        run: |
+          RESPONSE=$(curl -s -X POST "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys" \
+               -H "Authorization: Bearer $RENDER_API_KEY" \
+               -H "Content-Type: application/json")


### PR DESCRIPTION
Previously taken out due to needing to change config from development to production manually. However, now that it changes dynamically, this script can be placed back